### PR TITLE
Design: uStreamer Debian package.

### DIFF
--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -55,7 +55,7 @@ This is the highest priority goal because it gives us the most value from migrat
 
 ### Goal
 
-Avoid making parallel changes in both `ansible-role-ustreamer`, and `ustreamer-debian` repos; when we later incrementally migrate uStreamer's Ansible role functionality to the Debian package.
+Avoid making parallel changes (i.e., bumping version numbers) in both `ansible-role-ustreamer`, and `ustreamer-debian` repos; when we later incrementally migrate uStreamer's Ansible role functionality to the Debian package.
 
 ### Steps
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -28,7 +28,8 @@ Avoid building uStreamer on the device, reducing the TinyPilot installation time
   - Build the Debian package in CI
 
     - Use Docker's `--platform` parameter to target both AMD64 and ARMv7 architectures
-    - Save the package file as an CI artifact which we can later manually attach to as GitHub release asset
+    - Save the package file as an CI artifact which we can later manually attach as a GitHub release asset
+      - This will only happen for a single release until we consolidate `ansible-role-ustreamer` with the TinyPilot repo, in milestone 2
 
   - Use `debhelper` to automatically build the uStreamer binary via its `Makefile`, similar to the [(official?) Debian package](https://salsa.debian.org/reedy/ustreamer/-/tree/master/)
   - Always build uStreamer using the `WITH_JANUS` make flag
@@ -39,7 +40,7 @@ Avoid building uStreamer on the device, reducing the TinyPilot installation time
 
 - Create a `ustreamer-debian` release
 
-  - Attach the latest Debian package CI artifact as a GitHub release asset
+  - Manually attach the latest Debian package CI artifact as a GitHub release asset
 
 - In `ansible-role-ustreamer`, install the appropriate uStreamer Debian package instead of building from source
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -63,7 +63,7 @@ Avoid making parallel changes in both `ansible-role-ustreamer`, and `ustreamer-d
 
 - Consolidate `ansible-role-ustreamer` with TinyPilot repo
 
-  - This is just a temporary solution so we can just move the contents of the `ansible-role-ustreamer` repo into a `ansible-role-ustreamer` directory in the root of the TinyPilot repo
+  - This is just a temporary solution so we can move the contents of the `ansible-role-ustreamer` repo into a `ansible-role-ustreamer` directory in the root of the TinyPilot repo
 
 - Bundle local version of `ansible-role-ustreamer`
 
@@ -73,11 +73,11 @@ Avoid making parallel changes in both `ansible-role-ustreamer`, and `ustreamer-d
 
 - Bundle local version of uStreamer's Debian package file
 
-## Milestone 3: Migrate all uStreamer Ansible role functionality to Debian package
+## Milestone 3: Partially migrate uStreamer Ansible role functionality to Debian package
 
 ### Goal
 
-Purge uStreamer's Ansible role.
+Migrate highest-impact and/or lowest-effort Ansible tasks to Debian package.
 
 ### Steps
 
@@ -87,6 +87,18 @@ Purge uStreamer's Ansible role.
 
 - Migrate creation of uStreamer user and group to uStreamer Debian package
 
+  - We do [something similar](https://github.com/tiny-pilot/tinypilot/blob/master/debian-pkg/debian/tinypilot.postinst#L15-L29) in TinyPilot's Debian package
+
+- Migrate [Janus static config files](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/tasks/install_janus.yml#L57-L58) to uStreamer Debian package
+
+## Milestone 4: Migrate remaining uStreamer Ansible role functionality to Debian package
+
+### Goal
+
+Purge uStreamer's Ansible role.
+
+### Steps
+
 - Install `yq` as part of the uStreamer Debian package
 
   - This is in preparation for migrating the uStreamer launcher script, which depends on `yq`
@@ -94,25 +106,33 @@ Purge uStreamer's Ansible role.
   - To avoid conflicts with system software, we could install `yq` to `/home/ustreamer/.local/bin`
     - https://unix.stackexchange.com/a/264495
 
-- Migrate `/boot/config.txt` to uStreamer Debian package
-
-- Migrate `/boot/cmdline.txt` to uStreamer Debian package
-
-- Migrate TC358743 EDID file to uStreamer Debian package
-
-- Migrate TC358743 EDID loader systemd service to uStreamer Debian package
-
 - Migrate [default uStreamer config for TC358743 chips](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/tasks/provision_tc358743.yml#L74-L81) to uStreamer's Debian package `postinstall` script
 
-  - This is required so that the Debian package can later generate the [default uStreamer launcher runtime config](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/tasks/install_launcher.yml#L37-L59)
+  - This gives us enough info to create the `/opt/ustreamer-launcher/configs.d/000-defaults.yml` file on devices with TC358743 chips
 
 - Migrate [default uStreamer config for non-TC358743 chips](https://github.com/tiny-pilot/tinypilot/blob/master/bundler/bundle/install#L83-L93) to uStreamer's Debian package `postinstall` script
 
+  - This gives us enough info to create the `/opt/ustreamer-launcher/configs.d/000-defaults.yml` file on devices with non-TC358743 chips
   - This isn't strictly required, but it would be nice to consolidate all the default uStreamer launcher config in one place
 
 - Migrate uStreamer launcher script to uStreamer Debian package
 
-- Migrate Janus config to uStreamer Debian package
+  - This requires all dynamically determined uStreamer config (i.e., [default config for TC358743 chips](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/tasks/provision_tc358743.yml#L74-L81)) to live within the uStreamer Debian package
+  - After this task, all uStreamer's command-line arguments will be consolidated within uStreamer's Debian package
+
+- Migrate the provisioning of the TC358743 chip, which consists of the following sub-tasks:
+
+  - Migrate `/boot/config.txt` to uStreamer Debian package
+
+  - Migrate `/boot/cmdline.txt` to uStreamer Debian package
+
+  - Migrate TC358743 EDID file to uStreamer Debian package
+
+  - Migrate TC358743 EDID loader systemd service to uStreamer Debian package
+
+- Migrate uStreamer Janus plugin config to uStreamer Debian package
+
+  - This depends on the [value of `ustreamer_capture_device`](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/templates/janus.plugin.ustreamer.jcfg.j2#L5)
 
 - Migrate uStreamer systemd service to uStreamer Debian package
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -4,12 +4,9 @@ This ticket is the result of https://github.com/tiny-pilot/ustreamer-debian/issu
 
 We want to reimplement `ansible-role-ustreamer` functionality as a Debian package.
 
-We'll do so by incrementally migrating Ansible functionality over to the Debian package, in the following milestones:
+# Background
 
-1. Install uStreamer via a Debian package instead of compiling from source
-2. Migrate uStreamer launcher to Debian package
-3. All other uStreamer functionality
-4. Consolidate `ansible-role-ustreamer` repo with TinyPilot repo
+We've found that running Ansible is generally a slow process that might not be well suited for installing TinyPilot and TinyPilot related software, like uStreamer. We've already partially migrated our TinyPilot installation away from Ansible to a Debian package and we'd like to do the same with our uStreamer installation. Using a Debian package speeds up the installation process by using simple bash scripts, as opposed to Python in Ansible, and skipping an installation when the versions are the same.
 
 # Milestone tasks
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -10,7 +10,7 @@ We've found that running Ansible is generally a slow process that might not be w
 
 # Milestone tasks
 
-## Milestone 1
+## Milestone 1: Install uStreamer via a Debian package instead of compiling from source
 
 - Archive the `ustreamer-debian` repo
 
@@ -37,7 +37,7 @@ We've found that running Ansible is generally a slow process that might not be w
 
     - Skip Ansible tasks that would otherwise be handled by the Debian package
 
-## Milestone 2
+## Milestone 2: Migrate uStreamer launcher to Debian package
 
 - In Ansible, drop support for building uStreamer from source
 
@@ -64,13 +64,13 @@ We've found that running Ansible is generally a slow process that might not be w
 
 - Migrate uStreamer launcher script to Debian package
 
-## Milestone 3
+## Milestone 3: All other uStreamer functionality
 
 - Migrate Janus config to Debian package
 
 - Migrate uStreamer systemd service to Debian package
 
-## Milestone 4
+## Milestone 4: Consolidate `ansible-role-ustreamer` repo with TinyPilot repo
 
 - Consolidate `ansible-role-ustreamer` repo with TinyPilot repo
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -20,35 +20,35 @@ This ticket only outlines the tasks and milestones required achieve phase 1 abov
 
 - Drop support for Debian Buster
 
-  - Stripping the code that supports Debian Buster will simplify the Ansible tasks
+  - This includes dropping support for OMX
+  - Stripping the code that supports Debian Buster and OMX will simplify the Ansible tasks
 
-- Create a Dockerfile that builds multi-arch (i.e., AMD64, ARMv7) uStreamer binaries in CI
+- Create a Dockerfile that builds a uStreamer Debian package from source
 
-  - Use Docker's `--platform` parameter
-  - Store binaries as CI artifacts (for review)
-  - Always build uStreamer using the `WITH_JANUS` flag
+  - Use Docker's `--platform` parameter to target both AMD64 and ARMv7 architectures
+  - Use `debhelper` to automatically build the uStreamer binary via its `Makefile`, similar to the [(official?) Debian package](https://salsa.debian.org/reedy/ustreamer/-/tree/master/)
+  - Always build uStreamer using the `WITH_JANUS` make flag
+    - This requires adding `janus` as a Debian package dependency
+    - This requires adding `janus-dev` as a build dependency and patching Janus C header files to allow uStreamer to be built successfully
+    - Remember to install the resulting uStreamer Janus plugin shared library file (i.e., `libjanus_ustreamer.so`)
 
-- In Ansible, install the uStreamer binary instead of building from source
-
-  - Maintain building from source if the binary is not specified
-
-- Create a Dockerfile that builds a uStreamer Debian package
-
-  - The Debian package should only install the uStreamer binary
-  - Use `debhelper`
-
-- In Ansible, install the uStreamer Debian package instead of installing the uStreamer binary
+- In Ansible, install the appropriate uStreamer Debian package instead of building from source
 
   - Maintain building from source if the Debian package is not specified
 
-    - This might be complicated to maintain because tasks might be duplicated between Ansible and the Debian package
-    - If this seems to be too complicated then drop this requirement
+    - Skip Ansible tasks that would otherwise be handled by the Debian package
 
-- Remove the `load-tc358743-edid` service and let uStreamer set the custom EDID
+- In Ansible, drop support for building uStreamer from source
 
-  - uStreamer can now load a custom EDID before it starts. See https://github.com/pikvm/ustreamer#edid
+  - This is to avoid duplicating efforts/code between Ansible tasks and the Debian package
 
-- Migrate uStreamer launcher script to the Debian package
+- Migrate creation of uStreamer user and group to Debian package
+
+- Migrate uStreamer launcher script to Debian package
+
+  - Deprecate `/home/ustreamer/config.yml` file in favor of `/opt/ustreamer-launcher/configs.d/001-config.yml`
+
+    - Our uStreamer launcher script gives us a convenient way of overriding default uStreamer config via it's `configs.d` directory. There seems to be no reason why `config.yml` needs to be in a separate location.
 
 # Discussion
 
@@ -61,6 +61,10 @@ Agreed. The uStreamer binary gets built with no extra make flags, which we need.
 > @jdeanwallace will be project architect and advise the project based on his experience converting the TinyPilot Ansible role to Debian.
 
 Seeing as we haven't completed the migration from TinyPilot Ansible to TinyPilot Debian, should this design also be for a partial migration? My preference is to design for a partial migration up until installing the uStreamer binary via a Debian package because there would be less unknowns.
+
+> We need to decide whether it makes sense to manage the TC358743 EDID as part of the TinyPilot Debian package, the uStreamer Debian package, or somewhere else.
+
+uStreamer can now load a custom EDID before it starts, so it might make sense to keep the EDID in the uStreamer Debian package. See https://github.com/pikvm/ustreamer#edid
 
 # Resources
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -1,0 +1,33 @@
+This ticket is the result of https://github.com/tiny-pilot/ustreamer-debian/issues/1
+
+# Overview
+
+We want to reimplement `ansible-role-ustreamer` functionality as a Debian package.
+
+We'll do so by incrementally migrating Ansible functionality over to the Debian package, in the following phases:
+
+1. Install uStreamer via a Debian package instead of compiling from source
+2. All other functionality
+
+This ticket only outlines the tasks and milestones required achieve phase 1 above.
+
+# Tasks
+
+- Create a Dockerfile that builds multi-arch (i.e., AMD64, ARMv7) uStreamer binaries in CI
+
+  - Use Docker's `--platform` parameter
+  - Store binaries as CI artifacts (for review)
+  - Always build uStreamer using the `WITH_JANUS` flag
+
+- In Ansible, install the uStreamer binary instead of building from source
+
+  - Fallback to building from source if the binary is not specified
+
+- Create a Dockerfile that builds a uStreamer Debian package
+
+  - The Debian package should only install the uStreamer binary
+  - Use `debhelper`
+
+- In Ansible, install the uStreamer Debian package instead of installing the uStreamer binary
+
+  - Fallback to building from source if the Debian package is not specified

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -13,6 +13,15 @@ This ticket only outlines the tasks and milestones required achieve phase 1 abov
 
 # Tasks
 
+- Archive the `ustreamer-debian` repo
+
+  - For now, we'll create the uStreamer Debian package within the `ansible-role-ustreamer` repo
+  - Later, we might merge the `ansible-role-ustreamer` repo with the `tinypilot` repo
+
+- Drop support for Debian Buster
+
+  - Stripping the code that supports Debian Buster will simplify the Ansible tasks
+
 - Create a Dockerfile that builds multi-arch (i.e., AMD64, ARMv7) uStreamer binaries in CI
 
   - Use Docker's `--platform` parameter
@@ -21,7 +30,7 @@ This ticket only outlines the tasks and milestones required achieve phase 1 abov
 
 - In Ansible, install the uStreamer binary instead of building from source
 
-  - Fallback to building from source if the binary is not specified
+  - Maintain building from source if the binary is not specified
 
 - Create a Dockerfile that builds a uStreamer Debian package
 
@@ -30,4 +39,31 @@ This ticket only outlines the tasks and milestones required achieve phase 1 abov
 
 - In Ansible, install the uStreamer Debian package instead of installing the uStreamer binary
 
-  - Fallback to building from source if the Debian package is not specified
+  - Maintain building from source if the Debian package is not specified
+
+    - This might be complicated to maintain because tasks might be duplicated between Ansible and the Debian package
+    - If this seems to be too complicated then drop this requirement
+
+- Remove the `load-tc358743-edid` service and let uStreamer set the custom EDID
+
+  - uStreamer can now load a custom EDID before it starts. See https://github.com/pikvm/ustreamer#edid
+
+- Migrate uStreamer launcher script to the Debian package
+
+# Discussion
+
+> There's an [official [uStreamer] Debian package](https://salsa.debian.org/reedy/ustreamer/-/tree/master/debian)
+>
+> I don't think we can use it because we need the `WITH_JANUS` compilation option
+
+Agreed. The uStreamer binary gets built with no extra make flags, which we need. Besides, uStreamer Debian packages aren't up to date, even the [`unstable` suite only has version `4.9-1`](https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords=ustreamer).
+
+> @jdeanwallace will be project architect and advise the project based on his experience converting the TinyPilot Ansible role to Debian.
+
+Seeing as we haven't completed the migration from TinyPilot Ansible to TinyPilot Debian, should this design also be for a partial migration? My preference is to design for a partial migration up until installing the uStreamer binary via a Debian package because there would be less unknowns.
+
+# Resources
+
+- uStreamer launcher requires `yq`. To avoid conflicts with system software, our debian package can eventually install `yq` under `/home/ustreamer/.local/bin`
+
+  - https://unix.stackexchange.com/a/264495

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -10,7 +10,7 @@ We've found that running Ansible is generally a slow process that might not be w
 
 # Milestones
 
-## Milestone 1: Install uStreamer via a Debian package instead of compiling from source
+## Milestone 1: Install a pre-compiled uStreamer binary via a Debian package, while maintaining the ability to build uStreamer from source
 
 ### Goal
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -4,14 +4,16 @@ This ticket is the result of https://github.com/tiny-pilot/ustreamer-debian/issu
 
 We want to reimplement `ansible-role-ustreamer` functionality as a Debian package.
 
-We'll do so by incrementally migrating Ansible functionality over to the Debian package, in the following phases:
+We'll do so by incrementally migrating Ansible functionality over to the Debian package, in the following milestones:
 
 1. Install uStreamer via a Debian package instead of compiling from source
-2. All other functionality
+2. Migrate uStreamer launcher to Debian package
+3. All other uStreamer functionality
+4. Consolidate `ansible-role-ustreamer` repo with TinyPilot repo
 
-This ticket only outlines the tasks and milestones required achieve phase 1 above.
+# Milestone tasks
 
-# Tasks
+## Milestone 1
 
 - Archive the `ustreamer-debian` repo
 
@@ -38,17 +40,42 @@ This ticket only outlines the tasks and milestones required achieve phase 1 abov
 
     - Skip Ansible tasks that would otherwise be handled by the Debian package
 
+## Milestone 2
+
 - In Ansible, drop support for building uStreamer from source
 
   - This is to avoid duplicating efforts/code between Ansible tasks and the Debian package
 
 - Migrate creation of uStreamer user and group to Debian package
 
+- In Ansible, let uStreamer set the custom EDID
+
+  - uStreamer can now load a custom EDID before it starts, so it might make sense to keep the EDID in the uStreamer Debian package. See https://github.com/pikvm/ustreamer#edid
+  - This would replace our `load-tc358743-edid` service
+
+- Install `yq` as part of the uStreamer Debian package
+
+  - This is in preparation for migrating the uStreamer launcher script, which depends on `yq`
+  - This will help us to parse the `/home/ustreamer/config.yml` file and determine the value of `ustreamer_capture_device` which is needed to [provision the TC358743 chip](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/tasks/main.yml#L83-L85) and determine [uStreamer launcher runtime config](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/tasks/provision_tc358743.yml#L74-L81)
+
+- Migrate the provisioning of the TC358743 chip to Debian package
+
+  - Move [default uStreamer config for TC358743 chips](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/tasks/provision_tc358743.yml#L74-L81) to the Debian package's `postinstall` script
+    - This is required so that the Debian package can later generate the [default uStreamer launcher runtime config](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/master/tasks/install_launcher.yml#L37-L59)
+  - Move [default uStreamer config for non-TC358743 chips](https://github.com/tiny-pilot/tinypilot/blob/master/bundler/bundle/install#L83-L93) to the Debian package's `postinstall` script
+    - This isn't a requirement, but it would be nice to consolidate all the default uStreamer launcher config in one place
+
 - Migrate uStreamer launcher script to Debian package
 
-  - Deprecate `/home/ustreamer/config.yml` file in favor of `/opt/ustreamer-launcher/configs.d/001-config.yml`
+## Milestone 3
 
-    - Our uStreamer launcher script gives us a convenient way of overriding default uStreamer config via it's `configs.d` directory. There seems to be no reason why `config.yml` needs to be in a separate location.
+- Migrate Janus config to Debian package
+
+- Migrate uStreamer systemd service to Debian package
+
+## Milestone 4
+
+- Consolidate `ansible-role-ustreamer` repo with TinyPilot repo
 
 # Discussion
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -77,21 +77,7 @@ We'll do so by incrementally migrating Ansible functionality over to the Debian 
 
 - Consolidate `ansible-role-ustreamer` repo with TinyPilot repo
 
-# Discussion
-
-> There's an [official [uStreamer] Debian package](https://salsa.debian.org/reedy/ustreamer/-/tree/master/debian)
->
-> I don't think we can use it because we need the `WITH_JANUS` compilation option
-
-Agreed. The uStreamer binary gets built with no extra make flags, which we need. Besides, uStreamer Debian packages aren't up to date, even the [`unstable` suite only has version `4.9-1`](https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords=ustreamer).
-
-> @jdeanwallace will be project architect and advise the project based on his experience converting the TinyPilot Ansible role to Debian.
-
-Seeing as we haven't completed the migration from TinyPilot Ansible to TinyPilot Debian, should this design also be for a partial migration? My preference is to design for a partial migration up until installing the uStreamer binary via a Debian package because there would be less unknowns.
-
-> We need to decide whether it makes sense to manage the TC358743 EDID as part of the TinyPilot Debian package, the uStreamer Debian package, or somewhere else.
-
-uStreamer can now load a custom EDID before it starts, so it might make sense to keep the EDID in the uStreamer Debian package. See https://github.com/pikvm/ustreamer#edid
+  - We should now be able to archive the `ansible-role-ustreamer` repo
 
 # Resources
 

--- a/DEBIAN-PKG.md
+++ b/DEBIAN-PKG.md
@@ -16,6 +16,8 @@ We've found that running Ansible is generally a slow process that might not be w
 
 Avoid building uStreamer on the device, reducing the TinyPilot installation time by about 20s.
 
+This is the highest priority goal because it gives us the most value from migrating uStreamer to a Debian package.
+
 ### Steps
 
 - In `ansible-role-ustreamer`, drop support for Debian Buster


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ustreamer-debian/issues/1

This PR adds a [design document](https://github.com/tiny-pilot/ustreamer-debian/blob/design-debian-pkg/DEBIAN-PKG.md) outlining the tasks required to migrate `ansible-role-ustreamer` functionality to a uStreamer Debian package.

This PR is not really meant to be merged, but rather converted into a separate "MEGA-TICKET".

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ustreamer-debian/2"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>