### PR TITLE
Add basic CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2.1
+jobs:
+  check_whitespace:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - checkout
+      - run:
+          name: Check for trailing whitespace
+          command: ./dev-scripts/check-trailing-whitespace
+      - run:
+          name: Check that all text files end in a trailing newline
+          command: ./dev-scripts/check-trailing-newline
+  check_bash:
+    docker:
+      - image: koalaman/shellcheck-alpine:v0.9.0
+    steps:
+      - run:
+          name: Install dependencies
+          command: apk add bash git openssh-client grep
+      - checkout
+      - run:
+          name: Run static analysis on bash scripts
+          command: ./dev-scripts/check-bash
+workflows:
+  test:
+    jobs:
+      - check_whitespace
+      - check_bash

--- a/dev-scripts/check-bash
+++ b/dev-scripts/check-bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Run static analysis on bash scripts.
+
+# Exit on first failing command.
+set -e
+
+# Exit on unset variable.
+set -u
+
+BASH_SCRIPTS=()
+
+while read -r filepath; do
+  if head -n 1 "${filepath}" | grep --quiet \
+    --regexp '#!/bin/bash' \
+    --regexp '#!/usr/bin/env bash' \
+    --regexp '#!/usr/sh' \
+    --regexp '#!/usr/bin/env sh' \
+    ; then
+      BASH_SCRIPTS+=("${filepath}")
+  fi
+done < <(git ls-files)
+
+readonly BASH_SCRIPTS
+
+shellcheck "${BASH_SCRIPTS[@]}"

--- a/dev-scripts/check-trailing-newline
+++ b/dev-scripts/check-trailing-newline
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Verify that all text files end in a trailing newline.
+
+# Exit on first failing command.
+set -e
+# Exit on unset variable.
+set -u
+
+success=0
+
+while read -r line; do
+  if ! [[ -s "${line}" && -z "$(tail -c 1 "${line}")" ]]; then
+    printf "File must end in a trailing newline: %s\n" "${line}" >&2
+    success=255
+  fi
+done < <(git ls-files \
+  | xargs grep ".*" \
+    --files-with-matches \
+    --binary-files=without-match \
+    --exclude="*.svg" \
+    --exclude="*third-party*")
+
+exit "${success}"

--- a/dev-scripts/check-trailing-whitespace
+++ b/dev-scripts/check-trailing-whitespace
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check for trailing whitespace
+
+# Exit on first failing command.
+set -e
+# Exit on unset variable.
+set -u
+
+while read -r line; do
+  if grep \
+    "\s$" \
+    --line-number \
+    --with-filename \
+    --binary-files=without-match \
+    --exclude="*third-party*" \
+    "${line}"; then
+    echo "Found trailing whitespace" >&2 ;
+    exit 1;
+  fi
+done < <(git ls-files)


### PR DESCRIPTION
Related https://github.com/tiny-pilot/ustreamer-debian/issues/3

To eventually build a uStreamer Debian package in CI, we first need basic CI config.

This PR copies the following scripts from the TinyPilot Community repo and executes them as CircleCI jobs:
* [`dev-scripts/check-bash`](https://github.com/tiny-pilot/tinypilot/blob/d4273b9fe6f1faa7539467ba4d4054f50b99eb8f/dev-scripts/check-bash)
* [`dev-scripts/check-trailing-newline`](https://github.com/tiny-pilot/tinypilot/blob/d4273b9fe6f1faa7539467ba4d4054f50b99eb8f/dev-scripts/check-trailing-newline)
* [`dev-scripts/check-trailing-whitespace`](https://github.com/tiny-pilot/tinypilot/blob/d4273b9fe6f1faa7539467ba4d4054f50b99eb8f/dev-scripts/check-trailing-whitespace)

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ustreamer-debian/5"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>