### PR TITLE
Port over Debian build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,6 @@ venv/
 
 # Node
 node_modules
-package-lock.json
 
 # Mac OS
 *.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,74 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Flask
+app_settings.cfg
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# virtualenv
+venv/
+
+# Vim
+*~
+*.sw?
+
+# Node
+node_modules
+package-lock.json
+
+# Mac OS
+*.DS_Store
+*.xcworkspace

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Build uStreamer Debian package.
+#
+# Usage:
+#   build-debian-pkg [target architectures]
+#
+# target architecture: A comma-separated list of architectures that Docker
+#   accepts for its --platform argument. If omitted, defaults to
+#   "linux/arm/v7,linux/amd64". The only supported targets are linux/arm/v7 and
+#   linux/amd64.
+#
+# Examples
+#  build-debian-pkg "linux/arm/v7"
+#  build-debian-pkg "linux/arm/v7,linux/amd64"
+
+# Exit on first failure.
+set -e
+
+# Echo commands before executing them, by default to stderr.
+set -x
+
+# Exit on unset variable.
+set -u
+
+readonly BUILD_TARGETS="${1:-linux/arm/v7,linux/amd64}"
+
+PKG_VERSION="$(date '+%Y%m%d%H%M%S')"
+readonly PKG_VERSION
+
+# Use plain Docker build progress output when we're running in CI.
+DOCKER_PROGRESS='auto'
+if [[ -n "${CI:-}" ]]; then
+  DOCKER_PROGRESS='plain'
+fi
+readonly DOCKER_PROGRESS
+
+DOCKER_BUILDKIT=1 docker buildx build \
+  --file Dockerfile \
+  --platform "${BUILD_TARGETS}" \
+  --build-arg PKG_VERSION="${PKG_VERSION}" \
+  --target=artifact \
+  --progress="${DOCKER_PROGRESS}" \
+  --output "type=local,dest=$(pwd)/build/" \
+  .

--- a/dev-scripts/enable-multiarch-docker
+++ b/dev-scripts/enable-multiarch-docker
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Configure Docker to support multiarch builds, allowing it to use QEMU to build
+# images targeting different CPU architectures.
+
+# Exit script on first failure.
+set -e
+
+# Echo commands before executing them, by default to stderr.
+set -x
+
+# Exit on unset variable.
+set -u
+
+# Enable multiarch builds with QEMU.
+docker run \
+  --rm \
+  --privileged \
+  multiarch/qemu-user-static \
+  --reset \
+  -p yes
+
+# Create multiarch build context.
+docker context create builder
+
+# Create multiplatform builder.
+docker buildx create builder \
+  --name builder \
+  --driver docker-container \
+  --use
+
+# Ensure builder has booted.
+docker buildx inspect --bootstrap


### PR DESCRIPTION
Related https://github.com/tiny-pilot/ustreamer-debian/issues/3

This PR ports overs scripts from other TinyPilot repos, with minimal modification:
* [`.gitignore`](https://github.com/tiny-pilot/ustreamer-debian/commit/44a1af0a23a237e76172869fa8a79bf487dbccea) based on version from [TinyPilot Community](https://github.com/tiny-pilot/tinypilot/blob/014300e0c8aade142d99b6f2bd2a20e7f231265a/.gitignore)
* [`dev-scripts/build-debian-pkg`](https://github.com/tiny-pilot/ustreamer-debian/commit/3d27316bb674a5aa47b48479db11fcbd59608b89) based on version from [TinyPilot draft PR "Set up TinyPilot virtual environment from Debian package"](https://github.com/tiny-pilot/tinypilot/blob/e09e2dc216ed0dc3224ea619b819e9f99f0f7b02/dev-scripts/build-debian-pkg)
* [`dev-scripts/enable-multiarch-docker`](https://github.com/tiny-pilot/ustreamer-debian/commit/7f0840f560d5d94c49692e6c431ecf3a909cd551) based on version from [TinyPilot draft PR "Set up TinyPilot virtual environment from Debian package"](https://github.com/tiny-pilot/tinypilot/blob/e09e2dc216ed0dc3224ea619b819e9f99f0f7b02/dev-scripts/enable-multiarch-docker)

These scripts will be used in subsequent PRs to help build our uStreamer Debian package.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ustreamer-debian/7"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>