### PR TITLE
Create ustreamer user/group in post install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ Build-Depends: debhelper (>= 11),
 
 Package: ${PKG_NAME}
 Architecture: ${PKG_ARCH}
-Depends: \${shlibs:Depends}, \${misc:Depends}
+Depends: \${shlibs:Depends}, \${misc:Depends}, adduser
 Homepage: https://github.com/tiny-pilot/ustreamer
 Description: Lightweight and fast MJPEG-HTTP streamer
  µStreamer is a lightweight and very quick server to stream MJPEG video

--- a/debian/ustreamer.postinst
+++ b/debian/ustreamer.postinst
@@ -26,7 +26,8 @@ adduser \
   --home "${USTREAMER_HOME_DIR}" \
   "${USTREAMER_USER}"
 
-# Give user access to video devices.
+# Give user access to video devices. The `video` system group is predefined by
+# Debian for granting users access to video hardware.
 usermod \
   --append \
   --groups video \

--- a/debian/ustreamer.postinst
+++ b/debian/ustreamer.postinst
@@ -16,7 +16,7 @@ getent group "${USTREAMER_GROUP}" > /dev/null || \
     --system \
     "${USTREAMER_GROUP}"
 
-# adduser is idempotent, so we don't need to check existence first.
+# Create user, if it doesn't already exist.
 adduser \
   --system \
   `# We have to specify a shell to override the default /usr/sbin/nologin, ` \

--- a/debian/ustreamer.postinst
+++ b/debian/ustreamer.postinst
@@ -25,3 +25,9 @@ adduser \
   --ingroup "${USTREAMER_GROUP}" \
   --home "${USTREAMER_HOME_DIR}" \
   "${USTREAMER_USER}"
+
+# Give user access to video devices.
+usermod \
+  --append \
+  --groups video \
+  "${USTREAMER_USER}"

--- a/debian/ustreamer.postinst
+++ b/debian/ustreamer.postinst
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Exit on first failure.
+set -e
+
+# Exit on unset variable.
+set -u
+
+readonly USTREAMER_USER='ustreamer'
+readonly USTREAMER_GROUP="${USTREAMER_USER}"
+readonly USTREAMER_HOME_DIR="/home/${USTREAMER_USER}"
+
+# Create group, if it doesn't already exist.
+getent group "${USTREAMER_GROUP}" > /dev/null || \
+  addgroup \
+    --system \
+    "${USTREAMER_GROUP}"
+
+# adduser is idempotent, so we don't need to check existence first.
+adduser \
+  --system \
+  `# We have to specify a shell to override the default /usr/sbin/nologin, ` \
+  `# which prevents us from executing commands through "sudo su".` \
+  --shell /bin/bash \
+  --ingroup "${USTREAMER_GROUP}" \
+  --home "${USTREAMER_HOME_DIR}" \
+  "${USTREAMER_USER}"


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ustreamer-debian/issues/11

In our continued war on Ansible, this PR replicates [these Ansible tasks](https://github.com/tiny-pilot/tinypilot/blob/0fce6c4530880b76d1c5b212b57a3aebed446226/ansible-role-ustreamer/tasks/main.yml#L37-L49) by creating the `ustreamer` user/group as part of Debian's post-install script. 

Notes
1. Once we https://github.com/tiny-pilot/tinypilot/issues/1428 we can also remove the above referenced Ansible tasks.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ustreamer-debian/13"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>