### PR TITLE
Upgrade ustreamer to v6.36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ EOF
 ARG TARGETPLATFORM
 
 ARG PKG_NAME='ustreamer'
-ARG PKG_VERSION='6.24'
+ARG PKG_VERSION='6.36'
 
 # This should be a timestamp, formatted `YYYYMMDDhhmmss`. That way the package
 # manager always installs the most recently built package.


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1483.

This PR upgrades the uStreamer library from 5.43 to 6.36 (the latest as of this PR).

[uStreamer’s `6.24` release](https://github.com/pikvm/ustreamer/compare/v6.23...v6.24) (specifically in [`config.c`](https://github.com/pikvm/ustreamer/compare/v6.23...v6.24#diff-e5fe0ac4847bcb988b61f9e93b0d6ac773f22b564b5dd96ac53e5005632a895a) ) introduced breaking changes in the structure of the uStreamer<>Janus plugin configuration file:

- `memsink.object` is now `video.sink`.
- `audio` is now `acap` (presumably “audio capture”)
- There is a new section available: `aplay` (“audio playback”? Not sure…). This seems to be related to microphone support, at least it doesn’t seem to be needed for just *playing* audio.

On a Voyager 2a device, a full working `/etc/janus/janus.plugin.ustreamer.jcfg` would look like this:

```
video: {
    sink = "tinypilot::ustreamer::h264"
}
acap: {
    device = "hw:1"
    tc358743 = "/dev/video0"
}
```

We’ll have to take over these changes [when writing the config file during install](https://github.com/tiny-pilot/tinypilot/blob/a9e7096c25a222741c25060776285e5f6ed43b51/debian-pkg/debian/tinypilot.postinst#L123-L139), see https://github.com/tiny-pilot/tinypilot/pull/1881.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ustreamer-debian/23"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>