### PR TITLE
Fix wording in release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ We publish releases manually on Github. When we're ready to publish a new releas
 ### Create a Github release
 
 1. Create a new Github release for ustreamer-debian.
-1. Make the release tag and title the version number and timestamp suffix from the `.deb`` files.
+1. Make the release tag and title the version number and timestamp suffix from the `.deb` file.
    - e.g., `ustreamer_5.38-20230802141939_amdhf.deb` would have the tag `5.38-20230802141939`.
 1. Click "Generate release notes."
 1. Upload the Debian package file you downloaded above.

--- a/README.md
+++ b/README.md
@@ -172,13 +172,13 @@ We publish releases manually on Github. When we're ready to publish a new releas
 1. Go to the CircleCI build for the most recent `master` branch.
 1. Click the `build_debian_package` CircleCI step.
 1. Go the the "Artifacts" tab.
-1. Download all `.deb*` files.
+1. Download the `*armhf.deb` file.
 
 ### Create a Github release
 
 1. Create a new Github release for ustreamer-debian.
 1. Make the release tag and title the version number and timestamp suffix from the `.deb`` files.
-   - e.g., `ustreamer_5.38-20230802141939_amd64.deb` would have the tag `5.38-20230802141939`.
+   - e.g., `ustreamer_5.38-20230802141939_amdhf.deb` would have the tag `5.38-20230802141939`.
 1. Click "Generate release notes."
-1. Upload the Debian package files you downloaded above.
+1. Upload the Debian package file you downloaded above.
 1. Click "Publish release."


### PR DESCRIPTION
Resolves #24

This change updates the README's Publishing releases section with more clear information on the debian package builds by removing references to ARM64 builds.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ustreamer-debian/25"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>