### PR TITLE
Install Janus 1.3.2 as build dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
                 "${file}"
             done < <(find . -name '*.deb')
 workflows:
-  test:
+  build:
     jobs:
       - check_whitespace
       - check_bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,8 @@ Build-Depends: debhelper (>= 11),
   libspeex-dev,
   libspeexdsp-dev,
   libopus-dev,
-  libglib2.0-dev
+  libglib2.0-dev,
+  libjansson-dev
 
 Package: ${PKG_NAME}
 Architecture: ${PKG_ARCH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 
 # Install Janus dependency.
 RUN wget --output-document /tmp/janus.deb \
-      https://output.circle-artifacts.com/output/job/66a9324c-4999-4029-b20b-2fea9e2ea974/artifacts/0/build/janus_1.3.2-20250807133758_armhf.deb && \
+      https://github.com/tiny-pilot/janus-debian/releases/download/1.3.2-20250808114245/janus_1.3.2-20250808114245_armhf.deb && \
     apt-get install --yes /tmp/janus.deb
 
 # Docker populates this value from the --platform argument. See

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,33 +4,21 @@
 
 FROM debian:bullseye-20220328-slim AS build
 
-RUN set -x && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+ARG DEBIAN_FRONTEND='noninteractive'
+
+RUN apt-get update && \
+    apt-get install --yes \
       debhelper \
       dpkg-dev \
       devscripts \
       git \
       build-essential \
-      wget \
-      gnupg
+      wget
 
-# Add bullseye-backports apt suite to later install janus dependency.
-RUN cat | bash <<'EOF'
-set -ex
-# Add keyring.
-wget \
-  --output-document - \
-  https://ftp-master.debian.org/keys/archive-key-11.asc | \
-  gpg \
-    --dearmor > \
-  /usr/share/keyrings/bullseye-archive-keyring.gpg
-# Add repository.
-echo 'deb [signed-by=/usr/share/keyrings/bullseye-archive-keyring.gpg] http://deb.debian.org/debian bullseye-backports main' > \
-  /etc/apt/sources.list.d/bullseye-backports.list
-# Update package index.
-apt-get update
-EOF
+# Install Janus dependency.
+RUN wget --output-document /tmp/janus.deb \
+      https://output.circle-artifacts.com/output/job/10689798-c704-46aa-b8b9-bef3d884ca58/artifacts/0/build/janus_1.3.2-20250804153046_armhf.deb && \
+    apt-get install --yes /tmp/janus.deb
 
 # Docker populates this value from the --platform argument. See
 # https://docs.docker.com/build/building/multi-platform/
@@ -94,7 +82,6 @@ Build-Depends: debhelper (>= 11),
   libjpeg-dev,
   uuid-dev,
   libbsd-dev,
-  janus-dev,
   libasound2-dev,
   libspeex-dev,
   libspeexdsp-dev,
@@ -127,13 +114,6 @@ RUN mk-build-deps \
       --install \
       --remove \
       control
-
-# Allow Janus C header files to be included when compiling third-party plugins.
-# https://github.com/tiny-pilot/ansible-role-tinypilot/issues/192
-RUN sed \
-      --in-place \
-      's/^#include "refcount\.h"$/#include "\.\.\/refcount\.h"/g' \
-      /usr/include/janus/plugins/plugin.h
 
 # Rename the placeholder build directory to the final package ID.
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,8 @@ Build-Depends: debhelper (>= 11),
   libasound2-dev,
   libspeex-dev,
   libspeexdsp-dev,
-  libopus-dev
+  libopus-dev,
+  libglib2.0-dev
 
 Package: ${PKG_NAME}
 Architecture: ${PKG_ARCH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 
 # Install Janus dependency.
 RUN wget --output-document /tmp/janus.deb \
-      https://output.circle-artifacts.com/output/job/10689798-c704-46aa-b8b9-bef3d884ca58/artifacts/0/build/janus_1.3.2-20250804153046_armhf.deb && \
+      https://output.circle-artifacts.com/output/job/66a9324c-4999-4029-b20b-2fea9e2ea974/artifacts/0/build/janus_1.3.2-20250807133758_armhf.deb && \
     apt-get install --yes /tmp/janus.deb
 
 # Docker populates this value from the --platform argument. See

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ case "${TARGETPLATFORM}" in
     exit 1
 esac
 echo "${PKG_ARCH}" > /tmp/pkg-arch
-echo "${PKG_NAME}-${PKG_VERSION}-${PKG_BUILD_NUMBER}-${PKG_ARCH}" > /tmp/pkg-id
+echo "${PKG_NAME}_${PKG_VERSION}-${PKG_BUILD_NUMBER}_${PKG_ARCH}" > /tmp/pkg-id
 EOF
 
 # We ultimately need the directory name to be the package ID, but there's no
@@ -78,6 +78,7 @@ Priority: optional
 Maintainer: TinyPilot Support <support@tinypilotkvm.com>
 Build-Depends: debhelper (>= 11),
   dh-exec,
+  pkg-config,
   libevent-dev,
   libjpeg-dev,
   uuid-dev,
@@ -103,7 +104,7 @@ EOF
 RUN cat >changelog <<EOF
 ${PKG_NAME} (${PKG_VERSION}-${PKG_BUILD_NUMBER}) bullseye; urgency=medium
 
-  * Latest µStreamer release.
+  * µStreamer ${PKG_VERSION} release.
 
  -- TinyPilot Support <support@tinypilotkvm.com>  $(date '+%a, %d %b %Y %H:%M:%S %z')
 EOF


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1494

This PR installs our Janus `1.3.2` Debian package as a build dependency in order to compile a compatible uStreamer Janus plugin.

Notes:
1. We no longer need to [patch Janus C header files](https://github.com/tiny-pilot/ansible-role-tinypilot/issues/192) to allow third-party plugins to be compiled (i.e., uStreamer Janus plugin) because it's been fixed upstream:
    - https://github.com/meetecho/janus-gateway/pull/3525
1. This PR also includes some minor fixes to be consistent with the way we build other Debian packages.
1. For testing on device, you can download and install the latest TinyPilot Pro bundle artifact from this PR's CircleCI workflow:
    - https://github.com/tiny-pilot/tinypilot-pro/pull/1585

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ustreamer-debian/26"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>