### PR TITLE
Remove AMD64 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Build Debian package
-          command: ./dev-scripts/build-debian-pkg linux/arm64
+          command: ./dev-scripts/build-debian-pkg
       - run:
           name: Print Debian package contents
           command: |

--- a/dev-scripts/build-debian-pkg
+++ b/dev-scripts/build-debian-pkg
@@ -3,16 +3,8 @@
 # Build uStreamer Debian package.
 #
 # Usage:
-#   build-debian-pkg [target architectures]
+#   build-debian-pkg
 #
-# target architecture: A comma-separated list of architectures that Docker
-#   accepts for its --platform argument. If omitted, defaults to
-#   "linux/arm64,linux/amd64". The only supported targets are linux/arm64 and
-#   linux/amd64.
-#
-# Examples
-#  build-debian-pkg "linux/arm64"
-#  build-debian-pkg "linux/arm64,linux/amd64"
 
 # Exit on first failure.
 set -e
@@ -23,7 +15,7 @@ set -x
 # Exit on unset variable.
 set -u
 
-readonly BUILD_TARGETS="${1:-linux/arm64,linux/amd64}"
+readonly BUILD_TARGETS='linux/arm64'
 
 PKG_BUILD_NUMBER="$(date '+%Y%m%d%H%M%S')"
 readonly PKG_BUILD_NUMBER


### PR DESCRIPTION
Related: https://github.com/tiny-pilot/tinypilot-pro/issues/1829

This change removes the architecture options from `build-debian-pkg`, leaving `arm64` as the only build platform.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ustreamer-debian/30"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>